### PR TITLE
Raise `AsyncDependencyForbiddenError ` on async function provided as dependency.

### DIFF
--- a/giveme/injector.py
+++ b/giveme/injector.py
@@ -10,6 +10,10 @@ class DependencyNotFoundError(Exception):
     pass
 
 
+class AsyncDependencyProvided(Exception):
+    pass
+
+
 class DependencyNotFoundWarning(RuntimeWarning):
     pass
 
@@ -101,6 +105,8 @@ class Injector:
             raise DependencyNotFoundError(name) from None
         value = self.cached(dep)
         if value is None:
+            if iscoroutinefunction(dep.factory):
+                raise AsyncDependencyProvided(name)
             value = dep.factory()
             self.cache(dep, value)
         return value

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,7 @@ from functools import wraps
 from multiprocessing.pool import ThreadPool
 
 from giveme import register, inject, DependencyNotFoundError
+from giveme.injector import AsyncDependencyProvided
 
 
 def test_inject():
@@ -236,6 +237,9 @@ def simple_dep():
     return 42
 
 
+async def async_simple_dep():
+    return 566
+
 def double_dep(simple_dep):
     return simple_dep*2
 
@@ -451,3 +455,14 @@ def test_clear_injector(gm):
 
     with pytest.raises(TypeError):
         f()
+
+
+@pytest.mark.asyncio
+async def test_inject_async_dep(gm):
+    gm.register(async_simple_dep)
+
+    @gm.inject
+    async def f(async_simple_dep):
+        return async_simple_dep
+    with pytest.raises(AsyncDependencyProvided):
+        await f()

--- a/tests.py
+++ b/tests.py
@@ -5,7 +5,7 @@ from functools import wraps
 from multiprocessing.pool import ThreadPool
 
 from giveme import register, inject, DependencyNotFoundError
-from giveme.injector import AsyncDependencyProvided
+from giveme.injector import AsyncDependencyForbiddenError
 
 
 def test_inject():
@@ -240,6 +240,7 @@ def simple_dep():
 async def async_simple_dep():
     return 566
 
+
 def double_dep(simple_dep):
     return simple_dep*2
 
@@ -459,10 +460,5 @@ def test_clear_injector(gm):
 
 @pytest.mark.asyncio
 async def test_inject_async_dep(gm):
-    gm.register(async_simple_dep)
-
-    @gm.inject
-    async def f(async_simple_dep):
-        return async_simple_dep
-    with pytest.raises(AsyncDependencyProvided):
-        await f()
+    with pytest.raises(AsyncDependencyForbiddenError):
+        gm.register(async_simple_dep)


### PR DESCRIPTION
Realisation of #10 

> If you try to pass async function as dependency - you get an understandable mistake that you did wrong